### PR TITLE
add daily comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This module contains three distinct steps, which will be linked up in the final 
   3. Calculate metrics and produce plots to compare outputs from (1) and (2)
 
 Supported variables:
-  - 'streamflow' (USGS)
-  - 'water_table_depth' (USGS)
-  - 'swe' (SNOTEL)
-  - 'latent_heat' (AmeriFlux) 
+  - 'streamflow' (USGS) ('hourly' or 'daily')
+  - 'water_table_depth' (USGS) ('hourly' or 'daily')
+  - 'swe' (SNOTEL) ('daily')
+  - 'latent_heat' (AmeriFlux) ('hourly') 
 
 Supported metrics:
   - 'r2': Correlation of determination

--- a/plots.py
+++ b/plots.py
@@ -158,6 +158,8 @@ def plot_time_series(
             ax.set_ylabel("Water Table Depth [m]")
         elif variable == "swe":
             ax.set_ylabel("Snow Water Equivalent [mm]")
+        elif variable == "latent_heat":
+            ax.set_ylabel("Latent Heat Flux [W/m^2]")
 
         plt.title(f"{site_name}")
         plt.savefig(f"{output_dir}/{variable}_{site_id}.png", bbox_inches="tight")


### PR DESCRIPTION
This PR adds an initial implementation of comparing against daily observations data (`temporal_resolution="daily"`). In this initial version, the code is specific to standard ParFlow variable and file naming conventions. Only observations already available at daily resolution are currently included in such daily comparisons.

This PR also includes a small update to `plot.py` that correctly labels time series plots when `variable="latent_heat"`. 