### PR TITLE
accommodate full conus grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code used to compare ParFlow simulated output to real-world observations.
 
-Please see `example_workflow.ipynb` for an example of how the functions in this module are intended to be used with each other. Note that the input in this example is a mask generated from a HUC (list) using `subsettools`. This is one method of generating a mask, but the workflow will work with any mask and accompanying bounds within either the conus1 or conus2 domain. This workflow is restricted to comparisons within the conus1 or conus2 domains.
+Please see `example_workflow.ipynb` for an example of how the functions in this module are intended to be used with each other. Note that the input in this example is a mask generated from a HUC (list) using `subsettools`. This is one method of generating a mask, but the workflow will work with any mask and accompanying bounds within either the conus1 or conus2 domain. This workflow is restricted to comparisons within the conus1 or conus2 domains. If you wish to use the entire conus1 or conus2 domain, use `utils.define_conus_domain("conus2")` to obtain the ij_bounds and mask for the full conus2 grid (or likewise for conus1).
 
 This module contains three distinct steps, which will be linked up in the final workflow:
   1. Gather site-level observations for a requested domain

--- a/model_evaluation.py
+++ b/model_evaluation.py
@@ -190,7 +190,7 @@ def get_observations(
         if variable in ["streamflow", "water_table_depth"]:
             kwargs["dataset"] = "usgs_nwis"
         elif variable == "swe":
-            kwargs["dataset"] = "usda_nrcs"
+            kwargs["dataset"] = "snotel"
         elif variable == "latent_heat":
             kwargs["dataset"] = "ameriflux"
     if kwargs.get("aggregation") is None:

--- a/utils.py
+++ b/utils.py
@@ -6,8 +6,51 @@ within the model_evaluation.evaluate method.
 """
 
 import numpy as np
+from hf_hydrodata import get_gridded_data
+from subsettools._error_checking import _validate_grid
+from subsettools.domain import _indices_to_ij
 
 HYDRODATA = "/hydrodata"
+
+
+def define_conus_domain(grid):
+    """
+    Define a domain consisting of the entire conus grid.
+
+    Parameters
+    ----------
+    grid : str
+        "conus1" or "conus2" representing the entire grid domain.
+
+    Returns
+    -------
+    A tuple (bounds, mask).
+
+        Bounds is a tuple of the form (imin, jmin, imax, jmax) representing the
+        bounds in the conus grid of the area defined by the HUC IDs in hucs.
+        imin, jmin, imax, jmax are the west, south, east and north sides of the
+        box respectively and all i,j indices are calculated relative to the
+        lower southwest corner of the domain.
+
+        Mask is a 2D numpy.ndarray that indicates which cells inside the bounding
+        box are part of the selected HUC(s).
+    """
+    _validate_grid(grid)
+
+    options = {
+        "dataset": "huc_mapping",
+        "grid": grid,
+        "file_type": "tiff",
+        "level": "2",
+    }
+    conus_domain = get_gridded_data(options)
+    conus_mask = np.isin(conus_domain, [0], invert=True).squeeze()
+    indices_j, indices_i = np.where(conus_domain > 0)
+
+    bounds = _indices_to_ij(indices_j, indices_i)
+    imin, jmin, imax, jmax = bounds
+
+    return bounds, conus_mask[jmin:jmax, imin:imax].astype(int)
 
 
 def check_mask_shape(mask, ij_bounds):


### PR DESCRIPTION
This PR adds a utility function to easily obtain the `ij_bounds` and `mask` for the full conus grid (for either "conus1" or "conus2"). The remaining functions are written only based on having these two inputs, so the remaining code accommodates comparison for the full conus grid as-is.