### PR TITLE
allow for missing values in observations time series

### DIFF
--- a/plots.py
+++ b/plots.py
@@ -1,4 +1,5 @@
 """Functions to support plotting within the model evaluation module."""
+
 import os
 from matplotlib.lines import Line2D
 import pandas as pd
@@ -163,6 +164,7 @@ def plot_time_series(
 
         plt.title(f"{site_name}")
         plt.savefig(f"{output_dir}/{variable}_{site_id}.png", bbox_inches="tight")
+        plt.close()
 
 
 def plot_compare_scatter(
@@ -279,10 +281,11 @@ def plot_metric_map(mask, metrics_df, variable, metrics_list, output_dir="."):
 
         if metric == "condon":
             ax.imshow(mask, origin="lower", cmap="Greys_r", alpha=0.1)
+            df_plot = metrics_df[metrics_df["condon"] != "Undefined"]
             points = ax.scatter(
-                metrics_df["domain_i"],
-                metrics_df["domain_j"],
-                c=metrics_df[metric].map(metric_cmap),
+                df_plot["domain_i"],
+                df_plot["domain_j"],
+                c=df_plot[metric].map(metric_cmap),
                 s=20,
             )
             # add categorical legend
@@ -439,8 +442,8 @@ def plot_condon_diagram(metrics_df, variable, output_dir="."):
             round(
                 df_plot[df_plot["condon"] == "Low bias, good shape"].shape[0]
                 / total_obs
+                * 100
             )
-            * 100
         )
         + "%",
         weight="bold",
@@ -453,8 +456,8 @@ def plot_condon_diagram(metrics_df, variable, output_dir="."):
             round(
                 df_plot[df_plot["condon"] == "High bias, good shape"].shape[0]
                 / total_obs
+                * 100
             )
-            * 100
         )
         + "%",
         weight="bold",
@@ -467,8 +470,8 @@ def plot_condon_diagram(metrics_df, variable, output_dir="."):
             round(
                 df_plot[df_plot["condon"] == "Low bias, poor shape"].shape[0]
                 / total_obs
+                * 100
             )
-            * 100
         )
         + "%",
         weight="bold",
@@ -481,8 +484,8 @@ def plot_condon_diagram(metrics_df, variable, output_dir="."):
             round(
                 df_plot[df_plot["condon"] == "High bias, poor shape"].shape[0]
                 / total_obs
+                * 100
             )
-            * 100
         )
         + "%",
         weight="bold",

--- a/utils.py
+++ b/utils.py
@@ -107,6 +107,34 @@ def get_domain_indices(ij_bounds, conus_indices):
     return (mapped_i, mapped_j)
 
 
+def remove_sparse_columns(df, min_obs_pct=None, min_obs_count=None):
+    """
+    Removes columns from a DataFrame that have fewer non-missing values than the specified threshold.
+
+    Parameters:
+    - df: pd.DataFrame
+    - min_obs_pct: float, optional — e.g. 0.95 means keep columns with at least 95% non-missing values
+    - min_obs_count: int, optional — e.g. 100 means keep columns with at least 100 non-missing values
+
+    Returns:
+    - pd.DataFrame: filtered DataFrame with columns removed
+
+    Raises:
+    - ValueError: if neither or both thresholds are specified
+    """
+    if (min_obs_pct is None) == (min_obs_count is None):
+        raise ValueError("You must specify exactly one of min_obs_pct or min_obs_count")
+
+    if min_obs_pct is not None:
+        threshold = df.shape[0] * min_obs_pct
+    else:
+        threshold = min_obs_count
+
+    # Keep only columns where non-missing count >= threshold
+    valid_cols = df.columns[df.notna().sum() >= threshold]
+    return df[valid_cols]
+
+
 def initialize_metrics_df(obs_metadata_df, metrics_list):
     """
     Initialize DataFrame table to store metrics output.


### PR DESCRIPTION
This PR adds a set of parameters that allows users to specify a threshold of missing/NaN observation values. This can be either a percentage (`missing_pct_threshold`) or a raw count (`missing_count_threshold`). The default is to only filter out sites that have no non-NaN values (via `remove_sites_no_data=True`). These two new parameters give users flexibility to allow evaluation on time series that might not have fully complete observations.


Additional updates to plotting code and metrics calculations to accommodate time series with some NaN values. Previous code assumed complete time series with no NaNs. When comparing against ParFlow time series, the matching timestep output is dropped for any timesteps with NaN observations.