### PR TITLE
Update parflow indexing to allow flexible time range

### DIFF
--- a/example_workflow.ipynb
+++ b/example_workflow.ipynb
@@ -10,11 +10,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "eaf87d56-66fe-4ac0-8964-bae8249aa1ad",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import datetime\n",
     "import pandas as pd\n",
     "import subsettools\n",
     "\n",
@@ -24,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5b5e5c2f-4161-4be6-a86c-0ef9d2c55d38",
    "metadata": {},
    "outputs": [],
@@ -39,8 +40,8 @@
     "\n",
     "\n",
     "# Define other inputs to workflow\n",
-    "start_date = \"2003-04-01 01:00:00\"\n",
-    "end_date = \"2003-04-30 00:00:00\"\n",
+    "start_date = datetime.datetime(2003, 4, 1, 1)\n",
+    "end_date = datetime.datetime(2003, 4, 30, 0)\n",
     "temporal_resolution = \"hourly\"\n",
     "\n",
     "parflow_runname=\"02040106_updated\"\n",
@@ -51,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f7289184-cbb8-4d67-a2b6-355fb3c0b147",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This PR updates the `get_parflow_output` function to accept a `datetime` instead of a string. The `get_observations` function accepts both, but the docstrings are updated to indicate that a `datetime` is expected. This update is carried through the provided `example_workflow.ipynb`.

This update facilitates functionality which allows a user to evaluate ParFlow output that does not start on the first of the water year and/or for which the number of ParFlow output files does not strictly match the number of timesteps being evaluated. The way this was previously, the number of timesteps needed to match the number of ParFlow files in the ParFlow directory. Now a user can define the date range to evaluate. The updated function converts that into timesteps and allows a user to specify the date associated with timestep 1 (if it is not the first of the water year). 