### PR TITLE
handle when ij_bounds is None

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code used to compare ParFlow simulated output to real-world observations.
 
-Please see `example_workflow.ipynb` for an example of how the functions in this module are intended to be used with each other. Note that the input in this example is a mask generated from a HUC (list) using `subsettools`. This is one method of generating a mask, but the workflow will work with any mask and accompanying bounds within either the conus1 or conus2 domain. This workflow is restricted to comparisons within the conus1 or conus2 domains. If you wish to use the entire conus1 or conus2 domain, use `utils.define_conus_domain("conus2")` to obtain the ij_bounds and mask for the full conus2 grid (or likewise for conus1).
+Please see `example_workflow.ipynb` for an example of how the functions in this module are intended to be used with each other. Note that the input in this example is a mask generated from a HUC (list) using `subsettools`. This is one method of generating a mask, but the workflow will work with any mask and accompanying bounds within either the conus1 or conus2 domain. This workflow is restricted to comparisons within the conus1 or conus2 domains. If you wish to use the entire conus1 or conus2 domain, set `ij_bounds = None` and use `utils.get_conus_mask("conus2")` to obtain the mask for the full conus2 grid (or likewise for conus1).
 
 This module contains three distinct steps, which will be linked up in the final workflow:
   1. Gather site-level observations for a requested domain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cssi_evaluation"
-version = "0.1.0"
+version = "0.1.1"
 description = "Model evaluation functions for the CSSI project"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/utils.py
+++ b/utils.py
@@ -8,50 +8,18 @@ within the model_evaluation.evaluate method.
 import datetime
 import numpy as np
 from hf_hydrodata import get_gridded_data
-from subsettools._error_checking import _validate_grid
-from subsettools.domain import _indices_to_ij
 
 HYDRODATA = "/hydrodata"
 
 
-def define_conus_domain(grid):
+def get_conus_mask(grid):
     """
-    Define a domain consisting of the entire conus grid.
-
-    Parameters
-    ----------
-    grid : str
-        "conus1" or "conus2" representing the entire grid domain.
-
-    Returns
-    -------
-    A tuple (bounds, mask).
-
-        Bounds is a tuple of the form (imin, jmin, imax, jmax) representing the
-        bounds in the conus grid of the area defined by the HUC IDs in hucs.
-        imin, jmin, imax, jmax are the west, south, east and north sides of the
-        box respectively and all i,j indices are calculated relative to the
-        lower southwest corner of the domain.
-
-        Mask is a 2D numpy.ndarray that indicates which cells inside the bounding
-        box are part of the selected HUC(s).
+    Get the CONUS mask for a given grid.
     """
-    _validate_grid(grid)
+    options = {"dataset": f"{grid}_domain", "variable": "mask"}
+    conus_mask = get_gridded_data(options).squeeze()
 
-    options = {
-        "dataset": "huc_mapping",
-        "grid": grid,
-        "file_type": "tiff",
-        "level": "2",
-    }
-    conus_domain = get_gridded_data(options)
-    conus_mask = np.isin(conus_domain, [0], invert=True).squeeze()
-    indices_j, indices_i = np.where(conus_domain > 0)
-
-    bounds = _indices_to_ij(indices_j, indices_i)
-    imin, jmin, imax, jmax = bounds
-
-    return bounds, conus_mask[jmin:jmax, imin:imax].astype(int)
+    return conus_mask.astype(int)
 
 
 def check_mask_shape(mask, ij_bounds):


### PR DESCRIPTION
This PR sets up some logic to facilitate filtering observations on the entire CONUS2 grid. Previously, the function required an `ij_bounds`. This was used to acquire a list of potential site_id values within those bounds. This works when a HUC is provided, which has relatively few sites within those bounds (even a few thousand is okay). However, when the grid bounds are the whole domain this produces a list of sites that results in too many parameters for the SQL query. In particular, this breaks when filtering on water table depth wells from the USGS NWIS because of how many wells are in the hf-hydrodata database (even though relatively few actually have time series observations).

Passing in `ij_bounds` as `None` removes the additional SQL query, which keeps the number of query parameters within the acceptable limit.