### PR TITLE
ensure index values are integers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cssi_evaluation"
-version = "0.1.2"
+version = "0.1.3"
 description = "Model evaluation functions for the CSSI project"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/cssi_evaluation/model_evaluation.py
+++ b/src/cssi_evaluation/model_evaluation.py
@@ -245,8 +245,8 @@ def get_observations(
         metadata_df = metadata_df[metadata_df["mask"] == 1]
         metadata_df.drop(columns=("mask"), inplace=True)
     else:
-        metadata_df["domain_i"] = metadata_df[f"{grid}_i"]
-        metadata_df["domain_j"] = metadata_df[f"{grid}_j"]
+        metadata_df["domain_i"] = metadata_df[f"{grid}_i"].astype(int)
+        metadata_df["domain_j"] = metadata_df[f"{grid}_j"].astype(int)
 
     # Add context variables to metadata DF
     metadata_df["grid"] = grid


### PR DESCRIPTION
ParFlow indexing assumes i/j index values in the metadata are integers. This PR updates a bug in the logic when no `ij_bounds` are supplied (entire conus grid use case) to ensure final values are integers.